### PR TITLE
Use cached diesel cli tool on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ services:
 cache: cargo
 
 install:
-  - cargo install diesel_cli --force
+  - cargo install diesel_cli || true
+  - diesel --version
 
 before_script:
   # Prepare DB


### PR DESCRIPTION
Compiling and installing the Diesel CLI tools is slow, hence
we should use a cached version if available.